### PR TITLE
chore: upgrade lighthouse to v7.0.2 (OpenFusionist fork)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -43,7 +43,7 @@ services:
     stop_grace_period: 1m
 
   beacon:
-    image: sigp/lighthouse:v7.0.0
+    image: ghcr.io/openfusionist/lighthouse:v7.0.2
     pull_policy: always
     command:
       - lighthouse
@@ -87,7 +87,7 @@ services:
     stop_grace_period: 1m
 
   validator:
-    image: sigp/lighthouse:v7.0.0
+    image: ghcr.io/openfusionist/lighthouse:v7.0.2
     pull_policy: always
     command:
       - lighthouse

--- a/importAccount.sh
+++ b/importAccount.sh
@@ -13,7 +13,7 @@ docker run \
   -v $(pwd)/consensus-data:/consensus-data \
   -v $VALIDATOR_KEYS_DIR:/validator_keys \
   -v $(pwd)/../network_config:/network_config \
-  sigp/lighthouse:latest \
+  ghcr.io/openfusionist/lighthouse:v7.0.2 \
   lighthouse \
   --testnet-dir=/network_config \
   --datadir=/consensus-data \

--- a/lighthouseWithdraw.sh
+++ b/lighthouseWithdraw.sh
@@ -20,7 +20,7 @@ docker run \
   -it \
   -v $(pwd)/../network_config:/network_config \
   -v "$(pwd)/${KEYFILE}:/${KEYFILE}" \
-  sigp/lighthouse:latest \
+  ghcr.io/openfusionist/lighthouse:v7.0.2 \
   lighthouse \
   --datadir=/consensus-data \
   --testnet-dir=/network_config \


### PR DESCRIPTION
Update beacon and validator Docker images from sigp/lighthouse to ghcr.io/openfusionist/lighthouse:v7.0.2.
Ref: https://github.com/OpenFusionist/lighthouse/releases/tag/v7.0.2